### PR TITLE
Add <!DOCTYPE html>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <script src="https://cdn.jsdelivr.net/npm/p5@1.1.9/lib/p5.js"></script>


### PR DESCRIPTION
Browsers sometimes enter a weird "quirks mode" if you don't include this. Easiest to just include it.

@regexBuster 