### PR TITLE
Switch to using ES modules

### DIFF
--- a/collisions.js
+++ b/collisions.js
@@ -1,4 +1,6 @@
-function resolveCollision({ a, b, normal }) {
+import {CircleMover} from './script.js'
+
+export function resolveCollision({ a, b, normal }) {
 	let relativeVelocityOfB = b.getVel().sub(a.getVel());
 
 	let velAlongNormal = relativeVelocityOfB.dot(normal);
@@ -20,7 +22,7 @@ function resolveCollision({ a, b, normal }) {
 }
 
 // Correcting the position of 2 objects so that they're not inside each other
-function positionalCorrection({ a, b, normal, penetrationDepth }) {
+export function positionalCorrection({ a, b, normal, penetrationDepth }) {
 	// How much of the penetration depth to move out at once
 	const percent = 0.2;
 	// Minimum penetration depth needed to do a correction
@@ -35,7 +37,7 @@ function positionalCorrection({ a, b, normal, penetrationDepth }) {
 }
 
 // returns null if not colliding
-function getManifold(a, b) {
+export function getManifold(a, b) {
 	if (a.mass === Infinity && b.mass === Infinity) return null;
 
 	return (
@@ -47,7 +49,7 @@ function getManifold(a, b) {
 	);
 }
 
-function getCircleCircleManifold(a, b) {
+export function getCircleCircleManifold(a, b) {
 	// vector from a to b
 	let normal = b.loc.copy().sub(a.loc)
 

--- a/coordTransforms.js
+++ b/coordTransforms.js
@@ -1,28 +1,28 @@
 // top right position of canvas in pixels
 // we need to make this a function because p5 isn't initialized yet
-const pixelOffset = () => createVector(0, 0);
+export const pixelOffset = () => createVector(0, 0);
 // ratio of pixels to original
-const pixelScale = () => 1;
+export const pixelScale = () => 1;
 
-function coordToPixels(vec) {
-	return vec.copy().mult(pixelScale()).add(pixelOffset());
+export function coordToPixels(vec) {
+  return vec.copy().mult(pixelScale()).add(pixelOffset());
 }
 
-function pixelsToCoord(vec) {
-	return vec.copy().subt(pixelOffset()).div(pixelScale());
+export function pixelsToCoord(vec) {
+  return vec.copy().subt(pixelOffset()).div(pixelScale());
 }
 
-function distToPixels(n) {
-	return n * pixelScale();
+export function distToPixels(n) {
+  return n * pixelScale();
 }
 
-function pixelsToDist(n) {
-	return n / pixelScale();
+export function pixelsToDist(n) {
+  return n / pixelScale();
 }
 
-const canvasContainer = document.getElementById('put-canvas-here')
+export const canvasContainer = document.getElementById("put-canvas-here");
 
-const canvasWidthPixels = () => canvasContainer.clientWidth;
-const canvasHeightPixels = () => canvasContainer.clientHeight;
-const canvasWidth = () => pixelsToDist(canvasWidthPixels())
-const canvasHeight = () => pixelsToDist(canvasHeightPixels())
+export const canvasWidthPixels = () => canvasContainer.clientWidth;
+export const canvasHeightPixels = () => canvasContainer.clientHeight;
+export const canvasWidth = () => pixelsToDist(canvasWidthPixels());
+export const canvasHeight = () => pixelsToDist(canvasHeightPixels());

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <meta charset="utf-8"/>
 
 <script defer src="https://cdn.jsdelivr.net/npm/p5@1.1.9/lib/p5.js"></script>
-<script defer src="coordTransforms.js"></script>
-<script defer src="collisions.js"></script>
-<script defer src="script.js"></script>
+<!-- <script defer src="coordTransforms.js"></script>
+<script defer src="collisions.js"></script> -->
+<script defer type="module" src="script.js"></script>
 
 <link rel="stylesheet" href="style.css">
 

--- a/script.js
+++ b/script.js
@@ -1,3 +1,18 @@
+import {
+  canvasContainer,
+  canvasHeight,
+  canvasHeightPixels,
+  canvasWidth,
+  canvasWidthPixels,
+  coordToPixels,
+  distToPixels,
+} from "./coordTransforms.js";
+import {
+  resolveCollision,
+  getManifold,
+  positionalCorrection,
+} from "./collisions.js";
+
 class Mover {
 	constructor({ 
 		mass = random(0.5, 3),
@@ -66,7 +81,7 @@ class BoxMover extends Mover {
 	}
 }
 
-class CircleMover extends Mover {
+export class CircleMover extends Mover {
 	constructor(options = {}) {
 		super(options);
 	}
@@ -240,12 +255,12 @@ const getInitialObjects = () => ([
 	}),
 ])
 
-function setup() {
+window.setup = function setup() {
 	canvas = createCanvas(canvasWidthPixels(), canvasHeightPixels());
 	// canvas.position(0, 0)
 	
 	// Move canvas into the #put-canvas-here element
-	document.getElementById('put-canvas-here').appendChild(document.querySelector('.p5Canvas'))
+	canvasContainer.appendChild(document.querySelector('.p5Canvas'))
 
 	allObjects = getInitialObjects();
 
@@ -288,7 +303,7 @@ function handleCollisions() {
 }
 
 //loops "constantly" to apply forces and have objects draw themselves
-function draw() {
+window.draw = function draw() {
 
 	background(0);
 
@@ -359,12 +374,12 @@ function friction(mov, c){
 	mov.applyForce(f);
 }
 
-function mousePressed() {
+window.mousePressed = function mousePressed() {
 	ruler.shape1.pressed();
  	ruler.shape2.pressed();
 }
 
-function mouseReleased() {
+window.mouseReleased = function mouseReleased() {
 	ruler.shape1.released();
 	ruler.shape2.released();
 }
@@ -383,6 +398,6 @@ function toggleRuler(){
 	ruler.shown = !ruler.shown;
 }
 
-function windowResized() {
+window.windowResized = function windowResized() {
 	resizeCanvas(canvasWidthPixels(), canvasHeightPixels());
 }


### PR DESCRIPTION
Normally, I would prefer to use ES modules, but p5 doesn't seem to be set up for that, which is why I had to add stuff to `window` in `script.js`. I'm not sure whether this is worth it or if it's better to stick to regular scripts for now.

This doesn't change the actual behavior of the page.